### PR TITLE
Sessions: use hex token instead of base64

### DIFF
--- a/sessions.js
+++ b/sessions.js
@@ -61,7 +61,7 @@ function md5(string) {
    var crypto = require('crypto');
    var hasher = crypto.createHash('md5');
    hasher.update(string);
-   return hasher.digest('base64');
+   return hasher.digest('hex');
 }
 
 function getExpires() {


### PR DESCRIPTION
Base64 includes '+' which needs to be URL-encoded, which complicates
things for the receiver just enough to make the hex representation
more useful and safer.
