### PR TITLE
Caching: Add an option to cache results in memcache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
+  - "6"
+  - "8"

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ var BlessYou = require('./server.js')
    ,argv = args()
    ,fs   = require('fs')
    ,Cache = require('./cache.js')
+   ,Memcached = require('memcached')
    ,l    = console.log;
 
 function args() {
@@ -19,13 +20,13 @@ function args() {
 
 function getCacheFromArgs() {
    if (argv['memcache-server']) {
-      const memcache = {
-         server: argv['memcache-server'],
+      const config = {
+         memcache: new Memcached(argv['memcache-server']),
          expireTime: argv['memcache-expire-time']
       }
 
       l("Using memcache");
-      return Cache(memcache);
+      return Cache(config);
    }
 }
 

--- a/app.js
+++ b/app.js
@@ -2,9 +2,8 @@ var BlessYou = require('./server.js')
    ,yargs= require('yargs')
    ,argv = args()
    ,fs   = require('fs')
+   ,Cache = require('./cache.js')
    ,l    = console.log;
-
-var server = new BlessYou();
 
 function args() {
    return yargs.usage("Usage: $0 --port=<port> [--host=<host-ip>] [--pid-file=path]")
@@ -12,9 +11,27 @@ function args() {
       .demand('port')
       .describe('host', 'tcp host to accept connections from.')
       .default('host', '127.0.0.1')
+      .describe('memcache-server', 'i.e. 127.0.0.1:11211')
+      .describe('memcache-expire-time', 'expire time in seconds for compiled css stored in memcache')
       .describe('pid-file', 'file path to save the current pid in')
       .argv
 }
+
+function getCacheFromArgs() {
+   if (argv['memcache-server']) {
+      const memcache = {
+         server: argv['memcache-server'],
+         expireTime: argv['memcache-expire-time']
+      }
+
+      l("Using memcache");
+      return Cache(memcache);
+   }
+}
+
+argv.cache = getCacheFromArgs()
+
+var server = new BlessYou(argv);
 
 server.listen(argv.port, argv.host, function() {
    l("http server listening on: " + argv.host + ":" + argv.port); 

--- a/cache.js
+++ b/cache.js
@@ -37,7 +37,7 @@ function getCacheKey(req) {
    return md5([
       req.session && req.session.token,
       req.body,
-      JSON.stringify(req.parseOptions) || ''
+      JSON.stringify(req.parserOptions) || ''
    ]);
 }
 

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,31 @@
+module.exports = function Cache(config) {
+   return {
+      getCachedResponse: function(req) {
+         return new Promise(function(resolve, reject) {
+            req.fromCache = false;
+            req.cacheKey = getCacheKey(req.session, req.body, req.parserOptions);
+            resolve(null);
+         })
+      },
+
+      setCachedResponse: function(req, css) {
+         if (req.fromCache) {
+            return css;
+         }
+         return new Promise(function(resolve, reject) {
+            resolve(css);
+         })
+      }
+   }
+}
+
+function getCacheKey(session, lessCode, parseOptions) {
+   return md5([lessCode, JSON.stringify(parseOptions) || '']);
+}
+
+function md5(strings) {
+   var crypto = require('crypto');
+   var hasher = crypto.createHash('md5');
+   strings.forEach(string => hasher.update(String(string)));
+   return hasher.digest('hex');
+}

--- a/cache.js
+++ b/cache.js
@@ -1,8 +1,7 @@
 const l = require('./log.js').log;
-const Memcached = require('memcached');
 
 module.exports = function Cache(config) {
-   const memcache = new Memcached(config.server || '127.0.0.1:11211');
+   const memcache = config.memcache;
    const expireTime = config.expireTime || 86400;
 
    return {

--- a/dummy-cache.js
+++ b/dummy-cache.js
@@ -1,0 +1,13 @@
+module.exports = {
+   getCachedResponse: function(req) {
+      return new Promise(function(resolve, reject) {
+         resolve(null);
+      })
+   },
+
+   setCachedResponse: function(req, css) {
+      return new Promise(function(resolve, reject) {
+         resolve(css);
+      })
+   }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "yargs": "~1.1.3"
    },
    "devDependencies": {
-      "mocha": "~1.17.0"
+      "mocha": "^5.2.0"
    },
    "main": "./server.js",
    "bin": "./app.js",

--- a/package.json
+++ b/package.json
@@ -3,27 +3,24 @@
    "version": "0.1.0",
    "author": "Daniel Beardsley <daniel.beardsley@gmail.com>",
    "repository": "https://github.com/iFixit/blessyou",
-
-   "licenses": [{
-      "type": "MIT"
-   }],
-
+   "licenses": [
+      {
+         "type": "MIT"
+      }
+   ],
    "dependencies": {
       "connect": "~2.14.2",
       "less": "1.6.3",
-      "yargs": "~1.1.3",
-      "q": "~1.0.0"
+      "memcached": "^2.2.2",
+      "q": "~1.0.0",
+      "yargs": "~1.1.3"
    },
-
    "devDependencies": {
       "mocha": "~1.17.0"
    },
-
    "main": "./server.js",
-
-   "bin" : "./app.js",
-
-   "scripts" : {
+   "bin": "./app.js",
+   "scripts": {
       "test": "mocha -C tests"
    }
 }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
    "dependencies": {
       "connect": "~2.14.2",
       "less": "1.6.3",
-      "memcached": "^2.2.2",
+      "memcached": "~2.2.2",
       "q": "~1.0.0",
       "yargs": "~1.1.3"
    },
    "devDependencies": {
-      "mocha": "^5.2.0"
+      "mocha": "~5.2.0"
    },
    "main": "./server.js",
    "bin": "./app.js",

--- a/server.js
+++ b/server.js
@@ -88,6 +88,7 @@ function handleFailure(req, res) {
    return function (err) {
       var message = less.formatError(err, {color:false})
       l("Got Error: " + req.url + "\n" +  message)
+      l(err);
       res.statusCode = 500;
       res.end("" + message)
    }

--- a/server.js
+++ b/server.js
@@ -64,12 +64,7 @@ function lookupSession(req, res, next) {
 
 function convertLess(req, res, next) {
    parseLess(req)
-   .then(function(ast) {
-      if (req.session) {
-         ast.rules = req.session.ast.rules.concat(ast.rules);
-      }
-      return ast;
-   })
+   .then(includeSessionContents(req))
    .then(renderCss(req, res))
    .then(outputCss(req, res))
    .then(logRequest(req, res))
@@ -90,6 +85,15 @@ function parseLess(req) {
    var parser = new less.Parser(req.parserOptions);
    parser.parse(req.body, deferred.makeNodeResolver());
    return deferred.promise;
+}
+
+function includeSessionContents(req) {
+   return function(ast) {
+      if (req.session) {
+         ast.rules = req.session.ast.rules.concat(ast.rules);
+      }
+      return ast;
+   }
 }
 
 function outputCss(req, res) {

--- a/server.js
+++ b/server.js
@@ -63,12 +63,16 @@ function lookupSession(req, res, next) {
 }
 
 function convertLess(req, res, next) {
-   parseLess(req)
-   .then(includeSessionContents(req))
-   .then(renderCss(req, res))
+   getCssForRequest(req, res)
    .then(outputCss(req, res))
    .then(logRequest(req, res))
    .fail(handleFailure(req, res));
+}
+
+function getCssForRequest(req, res) {
+   return parseLess(req)
+   .then(includeSessionContents(req))
+   .then(renderCss(req))
 }
 
 function handleFailure(req, res) {
@@ -104,7 +108,7 @@ function outputCss(req, res) {
    }
 }
 
-function renderCss(req, res) {
+function renderCss(req) {
    return function (parseTree) {
       return parseTree.toCSS(req.parserOptions);
    };

--- a/server.js
+++ b/server.js
@@ -73,6 +73,7 @@ function convertLess(req, res, next) {
       }
       return ast;
    })
+   .then(renderCss(req, res))
    .then(outputCss(req, res))
    .then(function(css) {
       time = process.hrtime(req.time);
@@ -101,14 +102,17 @@ function parseLess(req) {
 }
 
 function outputCss(req, res) {
-   return function (parseTree) {
-      var css = parseTree.toCSS(req.parserOptions);
+   return function (css) {
       res.writeHead(200, "Content-Type: text/css");
       res.end(css);
-      return Q.fcall(function(){
-         return css;
-      });
+      return css;
    }
+}
+
+function renderCss(req, res) {
+   return function (parseTree) {
+      return parseTree.toCSS(req.parserOptions);
+   };
 }
 
 function round(num, places) {

--- a/server.js
+++ b/server.js
@@ -65,7 +65,7 @@ function lookupSession(req, res, next) {
    if (req.query.session) {
       var session = sessions.get(req.query.session);
       if (!session || !session.ast) {
-         var error = new Error("Session "+req.query.session+" not found!")
+         var error = "Session "+req.query.session+" not found!";
          return handleFailure(req, res)(error);
       }
       req.session = session;

--- a/server.js
+++ b/server.js
@@ -5,10 +5,12 @@ var Q    = require('q')
    ,getBody = require('./get-body.js')
    ,parserOptions = require('./parser-options.js')
    ,sessions = require('./sessions.js')()
-   ,cache = require('./cache.js')()
+   ,Cache = require('./cache.js')
+   ,DummyCache = require('./dummy-cache.js')
+   ,cache = null
    ,l    = require('./log.js').log;
 
-module.exports = function() {
+module.exports = function(config) {
    var app = connect()
    .use(denyNonPosts)
    .use(receiveBody)
@@ -17,6 +19,14 @@ module.exports = function() {
    .use('/session', createSession)
    .use(lookupSession)
    .use(convertLess)
+
+   if (!config || !config.memcache) {
+      cache = DummyCache;
+      l("Using Dummy Cache");
+   } else {
+      l("Using memcache");
+      cache = Cache(config);
+   }
 
    return http.createServer(app)
 }

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
       l("Using Dummy Cache");
    } else {
       l("Using memcache");
-      cache = Cache(config);
+      cache = Cache(config.memcache);
    }
 
    return http.createServer(app)
@@ -146,7 +146,8 @@ function logRequest(req, res) {
       var ms = time[0]*1000 + time[1] / 1e6
       var outLength = Buffer.byteLength(css)
       var sizeMsg = round(req.body.length/1000) + "k -> " + round(outLength/1000) + "k"
-      l("("+round(ms)+"ms - "+sizeMsg+"):" + req.url)
+      var cacheMsg = req.fromCache ? 'hit' : 'miss';
+      l("("+round(ms)+"ms - "+sizeMsg+" cache:"+cacheMsg+"):" + req.url)
    }
 }
 

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ var Q    = require('q')
    ,getBody = require('./get-body.js')
    ,parserOptions = require('./parser-options.js')
    ,sessions = require('./sessions.js')()
-   ,Cache = require('./cache.js')
    ,DummyCache = require('./dummy-cache.js')
    ,cache = null
    ,l    = require('./log.js').log;
@@ -20,12 +19,10 @@ module.exports = function(config) {
    .use(lookupSession)
    .use(convertLess)
 
-   if (!config || !config.memcache) {
-      cache = DummyCache;
+   cache = config && config.cache;
+   if (!cache) {
       l("Using Dummy Cache");
-   } else {
-      l("Using memcache");
-      cache = Cache(config.memcache);
+      cache = DummyCache;
    }
 
    return http.createServer(app)

--- a/server.js
+++ b/server.js
@@ -6,10 +6,11 @@ var Q    = require('q')
    ,parserOptions = require('./parser-options.js')
    ,sessions = require('./sessions.js')()
    ,DummyCache = require('./dummy-cache.js')
-   ,cache = null
    ,l    = require('./log.js').log;
 
 module.exports = function(config) {
+   var cache = null;
+
    var app = connect()
    .use(denyNonPosts)
    .use(receiveBody)
@@ -26,130 +27,129 @@ module.exports = function(config) {
    }
 
    return http.createServer(app)
-}
 
-function denyNonPosts(req, res, next) {
-   if (req.method !== 'POST') {
-      res.statusCode = 404;
-      return res.end();
-   }
-   next();
-}
-
-function receiveBody(req, res, next) {
-   req.time = process.hrtime();
-   getBody(req).then(function(body) {
-      req.body = body;
+   function denyNonPosts(req, res, next) {
+      if (req.method !== 'POST') {
+         res.statusCode = 404;
+         return res.end();
+      }
       next();
-   })
-}
-
-function extractParserOptions(req, res, next) {
-   if (req.query.options) {
-      req.parserOptions = parserOptions(JSON.parse(req.query.options || null))
    }
-   next();
-}
 
-function createSession(req, res, next) {
-   sessions.create(req.body, req.parserOptions)
-   .then(function(session) {
-      res.end(session.token)
-   }).catch(handleFailure(res, req));
-}
+   function receiveBody(req, res, next) {
+      req.time = process.hrtime();
+      getBody(req).then(function(body) {
+         req.body = body;
+         next();
+      })
+   }
 
-function lookupSession(req, res, next) {
-   if (req.query.session) {
-      var session = sessions.get(req.query.session);
-      if (!session || !session.ast) {
-         var error = "Session "+req.query.session+" not found!";
-         return handleFailure(req, res)(error);
+   function extractParserOptions(req, res, next) {
+      if (req.query.options) {
+         req.parserOptions = parserOptions(JSON.parse(req.query.options || null))
       }
-      req.session = session;
+      next();
    }
-   next();
-}
 
-function convertLess(req, res, next) {
-   getCssForRequest(req, res)
-   .then(outputCss(req, res))
-   .then(logRequest(req, res))
-   .catch(handleFailure(req, res));
-}
-
-function getCssForRequest(req, res) {
-   return cache.getCachedResponse(req)
-   .then(function(cachedCss) {
-      return cachedCss || parseAndRenderCss(req)
-   })
-}
-
-function parseAndRenderCss(req) {
-   return parseLess(req)
-   .then(includeSessionContents(req))
-   .then(renderCss(req))
-   .then(storeInCache(req))
-}
-
-function handleFailure(req, res) {
-   return function (err) {
-      var message = less.formatError(err, {color:false})
-      l("Got Error: " + req.url + "\n" +  message)
-      l(err);
-      res.statusCode = 500;
-      res.end("" + message)
+   function createSession(req, res, next) {
+      sessions.create(req.body, req.parserOptions)
+      .then(function(session) {
+         res.end(session.token)
+      }).catch(handleFailure(res, req));
    }
-}
-   
-function parseLess(req) {
-   var deferred = Q.defer()
-   var parser = new less.Parser(req.parserOptions);
-   parser.parse(req.body, deferred.makeNodeResolver());
-   return deferred.promise;
-}
 
-function includeSessionContents(req) {
-   return function(ast) {
-      if (req.session) {
-         ast.rules = req.session.ast.rules.concat(ast.rules);
+   function lookupSession(req, res, next) {
+      if (req.query.session) {
+         var session = sessions.get(req.query.session);
+         if (!session || !session.ast) {
+            var error = "Session "+req.query.session+" not found!";
+            return handleFailure(req, res)(error);
+         }
+         req.session = session;
       }
-      return ast;
+      next();
+   }
+
+   function convertLess(req, res, next) {
+      getCssForRequest(req, res)
+      .then(outputCss(req, res))
+      .then(logRequest(req, res))
+      .catch(handleFailure(req, res));
+   }
+
+   function getCssForRequest(req, res) {
+      return cache.getCachedResponse(req)
+      .then(function(cachedCss) {
+         return cachedCss || parseAndRenderCss(req)
+      })
+   }
+
+   function parseAndRenderCss(req) {
+      return parseLess(req)
+      .then(includeSessionContents(req))
+      .then(renderCss(req))
+      .then(storeInCache(req))
+   }
+
+   function handleFailure(req, res) {
+      return function (err) {
+         var message = less.formatError(err, {color:false})
+         l("Got Error: " + req.url + "\n" +  message)
+         l(err);
+         res.statusCode = 500;
+         res.end("" + message)
+      }
+   }
+      
+   function parseLess(req) {
+      var deferred = Q.defer()
+      var parser = new less.Parser(req.parserOptions);
+      parser.parse(req.body, deferred.makeNodeResolver());
+      return deferred.promise;
+   }
+
+   function includeSessionContents(req) {
+      return function(ast) {
+         if (req.session) {
+            ast.rules = req.session.ast.rules.concat(ast.rules);
+         }
+         return ast;
+      }
+   }
+
+   function outputCss(req, res) {
+      return function (css) {
+         res.writeHead(200, "Content-Type: text/css");
+         res.end(css);
+         return css;
+      }
+   }
+
+   function renderCss(req) {
+      return function (parseTree) {
+         return parseTree.toCSS(req.parserOptions);
+      };
+   }
+
+   function storeInCache(req) {
+      return function(css) {
+         return cache.setCachedResponse(req, css)
+      };
+   }
+
+   function logRequest(req, res) {
+      return function(css) {
+         var time = process.hrtime(req.time);
+         var ms = time[0]*1000 + time[1] / 1e6
+         var outLength = Buffer.byteLength(css)
+         var sizeMsg = round(req.body.length/1000) + "k -> " + round(outLength/1000) + "k"
+         var cacheMsg = req.fromCache ? 'hit' : 'miss';
+         l("("+round(ms)+"ms - "+sizeMsg+" cache:"+cacheMsg+"):" + req.url)
+      }
+   }
+
+   function round(num, places) {
+      var scale = Math.pow(10, places === undefined ? 1: places)
+      return Math.round(num*scale)/scale
    }
 }
-
-function outputCss(req, res) {
-   return function (css) {
-      res.writeHead(200, "Content-Type: text/css");
-      res.end(css);
-      return css;
-   }
-}
-
-function renderCss(req) {
-   return function (parseTree) {
-      return parseTree.toCSS(req.parserOptions);
-   };
-}
-
-function storeInCache(req) {
-   return function(css) {
-      return cache.setCachedResponse(req, css)
-   };
-}
-
-function logRequest(req, res) {
-   return function(css) {
-      var time = process.hrtime(req.time);
-      var ms = time[0]*1000 + time[1] / 1e6
-      var outLength = Buffer.byteLength(css)
-      var sizeMsg = round(req.body.length/1000) + "k -> " + round(outLength/1000) + "k"
-      var cacheMsg = req.fromCache ? 'hit' : 'miss';
-      l("("+round(ms)+"ms - "+sizeMsg+" cache:"+cacheMsg+"):" + req.url)
-   }
-}
-
-function round(num, places) {
-   var scale = Math.pow(10, places === undefined ? 1: places)
-   return Math.round(num*scale)/scale
-}
-

--- a/server.js
+++ b/server.js
@@ -63,9 +63,6 @@ function lookupSession(req, res, next) {
 }
 
 function convertLess(req, res, next) {
-   var time;
-   var inLength = req.body.length;
-
    parseLess(req)
    .then(function(ast) {
       if (req.session) {
@@ -75,13 +72,7 @@ function convertLess(req, res, next) {
    })
    .then(renderCss(req, res))
    .then(outputCss(req, res))
-   .then(function(css) {
-      time = process.hrtime(req.time);
-      var ms = time[0]*1000 + time[1] / 1e6
-      var outLength = Buffer.byteLength(css)
-      var sizeMsg = round(inLength/1000) + "k -> " + round(outLength/1000) + "k"
-      l("("+round(ms)+"ms - "+sizeMsg+"):" + req.url)
-   })
+   .then(logRequest(req, res))
    .fail(handleFailure(req, res));
 }
 
@@ -113,6 +104,16 @@ function renderCss(req, res) {
    return function (parseTree) {
       return parseTree.toCSS(req.parserOptions);
    };
+}
+
+function logRequest(req, res) {
+   return function(css) {
+      var time = process.hrtime(req.time);
+      var ms = time[0]*1000 + time[1] / 1e6
+      var outLength = Buffer.byteLength(css)
+      var sizeMsg = round(req.body.length/1000) + "k -> " + round(outLength/1000) + "k"
+      l("("+round(ms)+"ms - "+sizeMsg+"):" + req.url)
+   }
 }
 
 function round(num, places) {

--- a/server.js
+++ b/server.js
@@ -26,7 +26,11 @@ module.exports = function(config) {
       cache = DummyCache;
    }
 
-   return http.createServer(app)
+   const server = http.createServer(app)
+   server.on('close', () => {
+      sessions.close();
+   });
+   return server;
 
    function denyNonPosts(req, res, next) {
       if (req.method !== 'POST') {

--- a/sessions.js
+++ b/sessions.js
@@ -16,12 +16,12 @@ module.exports = function() {
 
    function createSession(lessCode, parseOverrides, token) {
       return parseLess(lessCode, parseOverrides).then(function(syntaxTree) {
-         sessions[token] = {
+         var session = new Session({
             token: token,
             ast: syntaxTree,
             expires: getExpires()
-         };
-         return sessions[token];
+         });
+         return sessions[token] = session;
       });
    }
 
@@ -68,4 +68,8 @@ function md5(string) {
 
 function getExpires() {
    return Date.now() + expireTime;
+}
+
+function Session(data) {
+   Object.assign(this, data);
 }

--- a/sessions.js
+++ b/sessions.js
@@ -36,7 +36,7 @@ module.exports = function() {
    }
 
    // Setup session expiration
-   setInterval(function() {
+   const interval = setInterval(function() {
       var now = Date.now();
       Object.keys(sessions).forEach(function(token) {
          if (sessions[token].expires < now) {
@@ -47,7 +47,8 @@ module.exports = function() {
 
    return {
       create: getOrCreateAst,
-      get: getSession
+      get: getSession,
+      close: () => clearInterval(interval)
    };
 }
 

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -3,54 +3,106 @@ require('../log.js').log = function(){};
 
 var fs   = require('fs')
    ,BlessYou = require('../server.js')
-   ,memoryCache = require('./memory-cache.js')()
+   ,MemoryCache = require('./memory-cache.js')
    ,Cache = require('../cache.js')
    ,assert = require('assert')
    ,post = require('./post.js')
    ,port = 38476
-   ,l    = require('../log.js').log;
 
 describe("Caching", function() {
+   var memoryCache = MemoryCache();
    var server = new BlessYou({
       cache: Cache({memcache: memoryCache})
    });
+
    before(function(done) {
       server.listen(port, null, done);
    });
 
-   it("should return a miss, then a hit", function(done) {
-      assertCacheMiss("a .b {\n  width: 1;\n}\n",  "a{.b{width:1}}")
+   var css = "a .b {\n  width: 1;\n}\n";
+   var less = "a{.b{width:1}}";
+
+   it("should return a miss, then a hit", function() {
+      return assertCacheMiss(css, less)
       .then(function() {
-         return assertCacheHit("a .b {\n  width: 1;\n}\n",  "a{.b{width:1}}")
+         return assertCacheHit(css, less)
+      });
+   });
+
+   it("should return a miss if less changes", function() {
+      const myLess = less + " ";
+      return assertCacheMiss(css, myLess)
+      .then(function() {
+         return assertCacheMiss(css, myLess + " ")
       })
-      .then(done).done();
+   });
+
+   it("should return a miss if less options change", function() {
+      var myLess = less + "a{}";
+      return assertCacheMiss(css, myLess)
+      .then(function() {
+         return assertCacheMiss(css, myLess, '?options={"a":2}')
+      })
+   });
+
+   describe("with a session", function() {
+      it("should return a miss if less options change", function() {
+         return withSession(".b() { width:1; }").then(sessionid => {
+            const myLess = "a{.b()}";
+            const myCss = "a {\n  width: 1;\n}\n";
+            const url = '?session=' + sessionid;
+            return assertCacheMiss(myCss, myLess, url)
+            .then(function() {
+               return assertCacheMiss(myCss, myLess, url + '&options={"a":2}')
+            })
+         })
+      });
+
+      it("should return a miss if the same less is compiled in a session", function() {
+         const myLess = less + "b{}";
+         return assertCacheMiss(css, myLess)
+         .then(function() {
+            return assertCacheHit(css, myLess)
+         }).then(() => {
+            return withSession(".b() { width:1; }")
+         }).then(sessionid => {
+            const url = '?session=' + sessionid;
+            return assertCacheMiss(css, myLess, url)
+            .then(function() {
+               return assertCacheHit(css, myLess, url)
+            })
+         })
+      });
    });
 
    after(function() {
       server.close();
    });
 
-   function assertCacheMiss(expectedCss, less) {
+   function assertCacheMiss(expectedCss, less, url) {
       const count = keyCount();
-      return assertCompiles(expectedCss, less).then(() =>
-         assert.equal(count + 1, keyCount())
+      return assertCompiles(expectedCss, less, url).then(() =>
+         assert.equal(count + 1, keyCount(), "wasn't a cache miss less:" + less + "url: " + url)
       );
    }
 
-   function assertCacheHit(expectedCss, less) {
+   function assertCacheHit(expectedCss, less, url) {
       const count = keyCount();
-      return assertCompiles(expectedCss, less).then(() =>
-         assert.equal(count, keyCount())
+      return assertCompiles(expectedCss, less, url).then(() =>
+         assert.equal(count, keyCount(), "wasn't a cache hit less:" + less + "url: " + url)
       );
    }
 
-   function assertCompiles(expectedCss, less) {
-      return post(port, '/', less)
+   function assertCompiles(expectedCss, less, url) {
+      return post(port, '/' + url, less)
       .then(function(body) {
          assert.equal(expectedCss, body);
       });
    }
 
+   function withSession(globalLess) {
+      return post(port, '/session', globalLess)
+   }
 
    function keyCount() {
       return Object.keys(memoryCache.getCache()).length;

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -1,0 +1,59 @@
+// disable logging during tests
+require('../log.js').log = function(){};
+
+var fs   = require('fs')
+   ,BlessYou = require('../server.js')
+   ,memoryCache = require('./memory-cache.js')()
+   ,Cache = require('../cache.js')
+   ,assert = require('assert')
+   ,post = require('./post.js')
+   ,port = 38476
+   ,l    = require('../log.js').log;
+
+describe("Caching", function() {
+   var server = new BlessYou({
+      cache: Cache({memcache: memoryCache})
+   });
+   before(function(done) {
+      server.listen(port, null, done);
+   });
+
+   it("should return a miss, then a hit", function(done) {
+      assertCacheMiss("a .b {\n  width: 1;\n}\n",  "a{.b{width:1}}")
+      .then(function() {
+         return assertCacheHit("a .b {\n  width: 1;\n}\n",  "a{.b{width:1}}")
+      })
+      .then(done).done();
+   });
+
+   after(function() {
+      server.close();
+   });
+
+   function assertCacheMiss(expectedCss, less) {
+      const count = keyCount();
+      return assertCompiles(expectedCss, less).then(() =>
+         assert.equal(count + 1, keyCount())
+      );
+   }
+
+   function assertCacheHit(expectedCss, less) {
+      const count = keyCount();
+      return assertCompiles(expectedCss, less).then(() =>
+         assert.equal(count, keyCount())
+      );
+   }
+
+   function assertCompiles(expectedCss, less) {
+      return post(port, '/', less)
+      .then(function(body) {
+         assert.equal(expectedCss, body);
+      });
+   }
+
+
+   function keyCount() {
+      return Object.keys(memoryCache.getCache()).length;
+   }
+});
+

--- a/tests/less.test.js
+++ b/tests/less.test.js
@@ -5,7 +5,7 @@ var fs   = require('fs')
    ,BlessYou = require('../server.js')
    ,assert = require('assert')
    ,post = require('./post.js')
-   ,port = 38475
+   ,port = 38474
 
 describe("Less compile via http", function() {
    var server = new BlessYou();

--- a/tests/memory-cache.js
+++ b/tests/memory-cache.js
@@ -1,0 +1,15 @@
+module.exports = function() {
+   let cache = {};
+   return {
+      get: function(key, callback) {
+         callback(null, cache[key]);
+      },
+
+      set: function(key, value, expire, callback) {
+         cache[key] = value;
+         callback();
+      },
+
+      getCache: () => cache
+   }
+}


### PR DESCRIPTION
Cache key is built from hash of less code + options + sesssionid.

Often compiling less takes ~5-50ms. Since less files just don't change
much and the result is deterministict, caching helps significantly
here.

I added a test that mocks the underlying memcache.

Closes #10 