### PR TITLE
Blessyou in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM alpine
 
 MAINTAINER Daryl "daryl@ifixit.com"
 
-RUN apk update && apk upgrade && apk add nodejs
+RUN apk update && apk upgrade && apk add nodejs npm
 
-ADD . /opt/blessyou
+
+WORKDIR /opt/blessyou
+COPY . .
+
+RUN npm install
 
 CMD /opt/blessyou/bin/blessyou --port=7355 --host=0.0.0.0

--- a/build
+++ b/build
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker build -t blessyou:latest .

--- a/build
+++ b/build
@@ -1,3 +1,5 @@
 #!/bin/bash -ex
 
-docker build -t blessyou:latest .
+docker build \
+ -t ${DEV_ECR_IMAGE_TAG:-blessyou}:${GO_REVISION_BLESSYOU_GIT:-latest} \
+ .

--- a/deploy
+++ b/deploy
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+echo "noop for now"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -ex
-
-# Build the bless you Docker container
-
-npm install
-
-docker build -t blessyou .

--- a/test
+++ b/test
@@ -1,0 +1,5 @@
+#!/bin/bash -ex
+
+docker run \
+   ${DEV_ECR_IMAGE_TAG:-blessyou}:${GO_REVISION_BLESSYOU_GIT:-latest} \
+   npm test


### PR DESCRIPTION
We want to dockizer blessyou to decouple it from the production wide version of Node.

Lets update the docker, and add `build`, `test`, `deploy` scripts to move blessyou into GoCD.

Ref: https://github.com/iFixit/ifixit/issues/31916

CC @zdmitchell 