### PR TITLE
Use `node:apline` in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM alpine 
+FROM node:16-alpine
 
 MAINTAINER Daryl "daryl@ifixit.com"
-
-RUN apk update && apk upgrade && apk add nodejs npm
-
 
 WORKDIR /opt/blessyou
 COPY . .


### PR DESCRIPTION
This lets us avoid having to "manully" install nodejs and npm in our Dockerfile.

CC @Michelle5102 